### PR TITLE
Revise README and add module docs placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Personal App
 
-This project provides a basic scaffold for a personal application.
-The goal is to separate the frontend and backend components while keeping
-related documentation in the `docs/` directory.
+This repository hosts a small Progressive Web App (PWA) project. The goal is to keep the frontend and backend separated while placing design documentation in the `docs/` directory.
 
-- `frontend/`: client-side code
-- `backend/`: server-side code
-- `docs/`: project documentation
+## Modules
+- **frontend/** – Next.js application with Tailwind CSS and `next-pwa` for offline capabilities.
+- **backend/** – Placeholder for API code. Add your preferred Node.js framework here.
+- **docs/** – Project documentation and design notes.
+
+## Local setup
+### Frontend
+1. `cd frontend`
+2. Run `npm install` to install dependencies.
+3. Start the dev server with `npm run dev`.
+
+### Backend
+1. `cd backend`
+2. Initialize the project with `npm init -y` if not already done.
+3. Add your server code (e.g., Express) and run it with `node <entry-file>`.
+
+## Contributing
+Future design notes and module plans will be stored in `docs/`.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,0 +1,3 @@
+# Backend Module
+
+TODO: Add design notes for the server/API implementation.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,3 @@
+# Frontend Module
+
+TODO: Add design notes for the Next.js PWA.


### PR DESCRIPTION
## Summary
- rewrite the README to introduce the PWA focus and give local setup instructions for the frontend and backend modules
- add placeholder design-note documents under `docs/`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685061c8e2c48328abea59f230fecd06