### PR TITLE
Integrate Telegram WebApp SDK

### DIFF
--- a/frontend/lib/telegram.ts
+++ b/frontend/lib/telegram.ts
@@ -1,0 +1,19 @@
+import '@twa-dev/sdk';
+
+declare global {
+  interface Window {
+    Telegram?: { WebApp?: any };
+  }
+}
+
+export const WebApp = typeof window === 'undefined' ? undefined : window.Telegram?.WebApp;
+
+export function init() {
+  if (WebApp && typeof WebApp.ready === 'function') {
+    WebApp.ready();
+  }
+}
+
+export function getThemeParams() {
+  return WebApp?.themeParams ?? {};
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "next": "14.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "next-pwa": "5.6.0"
+    "next-pwa": "5.6.0",
+    "@twa-dev/sdk": "^1.0.0"
   },
   "devDependencies": {
     "typescript": "5.2.2",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,8 +2,21 @@ import type { AppProps } from 'next/app';
 import '../app/globals.css';
 import Layout from '../components/Layout';
 import 'next-pwa/register';
+import { useEffect } from 'react';
+import { init, getThemeParams } from '../lib/telegram';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    init();
+    const theme = getThemeParams();
+    if (theme.bg_color) {
+      document.body.style.backgroundColor = theme.bg_color;
+    }
+    if (theme.text_color) {
+      document.body.style.color = theme.text_color;
+    }
+  }, []);
+
   return (
     <Layout>
       <Component {...pageProps} />


### PR DESCRIPTION
## Summary
- add `@twa-dev/sdk` dependency
- create `lib/telegram.ts` to init Telegram WebApp and expose theme
- use Telegram WebApp in `_app.tsx`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850647bc6508328b76d9c2cf78abf40